### PR TITLE
proof of dual_nnpp_1

### DIFF
--- a/temporal_logic.v
+++ b/temporal_logic.v
@@ -191,9 +191,15 @@ Qed.
 (* □p → ¬◇¬p *)
 Theorem dual_nnpp_1: forall p t valuation, (eval (Globally p) t valuation) -> not (eval (Not (Future p)) t valuation).
 Proof.
-admit.
-Admitted.
-
+simpl.
+intros p t valuation H H0.
+apply H0.
+exists t.
+split.
+omega.
+apply H.
+omega.
+Qed.
 
 (* ¬◇¬p → □p *)
 Theorem dual_nnpp_2: forall p t valuation, not (eval (Not (Future p)) t valuation) -> (eval (Globally p) t valuation).


### PR DESCRIPTION
Proof of: 
```coq
Theorem dual_nnpp_1: forall p t valuation, 
     (eval (Globally p) t valuation) -> not (eval (Not (Future p)) t valuation).
```